### PR TITLE
feat: Add lifecycle create_before_destroy to avoid timeout with security group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -142,6 +142,10 @@ resource "aws_security_group" "this" {
   vpc_id                 = var.security_group_vpc_id
 
   tags = var.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_security_group_rule" "this" {
@@ -159,6 +163,10 @@ resource "aws_security_group_rule" "this" {
   prefix_list_ids          = try(each.value.prefix_list_ids, null)
   self                     = try(each.value.self, null)
   source_security_group_id = try(each.value.source_security_group_id, null)
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 ################################################################################


### PR DESCRIPTION
## Description
* This is a PR regarding this issue https://github.com/terraform-aws-modules/terraform-aws-efs/issues/15

## Motivation and Context
* Fixes https://github.com/terraform-aws-modules/terraform-aws-efs/issues/15

## Breaking Changes
* No breaking change

## How Has This Been Tested?
- [*] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [*] I have tested and validated these changes using one or more of the provided `examples/*` projects
- [*] I have executed `pre-commit run -a` on my pull request
