### PR TITLE
fix: Use `lookup()` on computed resource attribute lookups in `for_each` loop

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.77.0
+    rev: v1.83.5
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -23,7 +23,7 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
 
 locals {
   region = "eu-west-1"
-  name   = "efs-ex-${replace(basename(path.cwd), "_", "-")}"
+  name   = "ex-${basename(path.cwd)}"
 
   azs = slice(data.aws_availability_zones.available.names, 0, 3)
 
@@ -135,9 +135,8 @@ module "vpc" {
   public_subnets  = ["10.99.0.0/24", "10.99.1.0/24", "10.99.2.0/24"]
   private_subnets = ["10.99.3.0/24", "10.99.4.0/24", "10.99.5.0/24"]
 
-  enable_nat_gateway      = false
-  single_nat_gateway      = true
-  map_public_ip_on_launch = false
+  enable_nat_gateway = false
+  single_nat_gateway = true
 
   tags = local.tags
 }

--- a/main.tf
+++ b/main.tf
@@ -158,11 +158,11 @@ resource "aws_security_group_rule" "this" {
   from_port                = try(each.value.from_port, 2049)
   to_port                  = try(each.value.to_port, 2049)
   protocol                 = try(each.value.protocol, "tcp")
-  cidr_blocks              = try(each.value.cidr_blocks, null)
-  ipv6_cidr_blocks         = try(each.value.ipv6_cidr_blocks, null)
-  prefix_list_ids          = try(each.value.prefix_list_ids, null)
+  cidr_blocks              = lookup(each.value, "cidr_blocks", null)
+  ipv6_cidr_blocks         = lookup(each.value, "ipv6_cidr_blocks", null)
+  prefix_list_ids          = lookup(each.value, "prefix_list_ids", null)
   self                     = try(each.value.self, null)
-  source_security_group_id = try(each.value.source_security_group_id, null)
+  source_security_group_id = lookup(each.value, "source_security_group_id", null)
 
   lifecycle {
     create_before_destroy = true

--- a/main.tf
+++ b/main.tf
@@ -129,10 +129,12 @@ resource "aws_efs_mount_target" "this" {
 
 locals {
   security_group_name = try(coalesce(var.security_group_name, var.name), "")
+
+  create_security_group = var.create && var.create_security_group && length(var.mount_targets) > 0
 }
 
 resource "aws_security_group" "this" {
-  count = var.create && var.create_security_group && length(var.mount_targets) > 0 ? 1 : 0
+  count = local.create_security_group ? 1 : 0
 
   name        = var.security_group_use_name_prefix ? null : local.security_group_name
   name_prefix = var.security_group_use_name_prefix ? "${local.security_group_name}-" : null
@@ -149,7 +151,7 @@ resource "aws_security_group" "this" {
 }
 
 resource "aws_security_group_rule" "this" {
-  for_each = { for k, v in var.security_group_rules : k => v if var.create && var.create_security_group }
+  for_each = { for k, v in var.security_group_rules : k => v if local.create_security_group }
 
   security_group_id = aws_security_group.this[0].id
 


### PR DESCRIPTION
## Description
- Use `lookup()` on computed resource attribute lookups in `for_each` loop
- Correct discrepancy in conditional creation logic of security group

## Motivation and Context
- Running into this error https://github.com/clowdhaus/terraform-for-each-unknown

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
