### PR TITLE
feat: Support new sg rules

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -177,6 +177,44 @@ resource "aws_security_group" "this" {
   }
 }
 
+resource "aws_vpc_security_group_egress_rule" "this" {
+  for_each = { for k, v in var.security_group_rules : k => v if local.create_security_group && try(v.type, "ingress") == "egress" }
+
+  security_group_id = aws_security_group.this[0].id
+
+  description                  = try(each.value.description, null)
+  from_port                    = try(each.value.from_port, 2049)
+  to_port                      = try(each.value.to_port, 2049)
+  ip_protocol                  = try(each.value.protocol, "tcp")
+  cidr_ipv4                    = lookup(each.value, "cidr_blocks", null)
+  cidr_ipv6                    = lookup(each.value, "ipv6_cidr_blocks", null)
+  prefix_list_id               = lookup(each.value, "prefix_list_ids", null)
+  referenced_security_group_id = lookup(each.value, "source_security_group_id", null)
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "this" {
+  for_each = { for k, v in var.security_group_rules : k => v if local.create_security_group && try(v.type, "ingress") == "ingress" }
+
+  security_group_id = aws_security_group.this[0].id
+
+  description                  = try(each.value.description, null)
+  from_port                    = try(each.value.from_port, 2049)
+  to_port                      = try(each.value.to_port, 2049)
+  ip_protocol                  = try(each.value.protocol, "tcp")
+  cidr_ipv4                    = lookup(each.value, "cidr_blocks", null)
+  cidr_ipv6                    = lookup(each.value, "ipv6_cidr_blocks", null)
+  prefix_list_id               = lookup(each.value, "prefix_list_ids", null)
+  referenced_security_group_id = lookup(each.value, "source_security_group_id", null)
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
 resource "aws_security_group_rule" "this" {
   for_each = { for k, v in var.security_group_rules : k => v if local.create_security_group }
 


### PR DESCRIPTION
## Description
Creates aws_vpc_security_group_ingress_rule and aws_vpc_security_group_egress_rule instead of aws_security_group_rule

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
As stated in the terraform registry of AWS:

> Using [aws_vpc_security_group_egress_rule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_egress_rule) and aws_vpc_security_group_ingress_rule resources is the current best practice. Avoid using the [aws_security_group_rule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) resource and the ingress and egress arguments of the [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) resource for configuring in-line rules, as they struggle with managing multiple CIDR blocks, and tags and descriptions due to the historical lack of unique IDs.


## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? --> 
It should not introduce breaking changes as I've tried to stay compatible with current security_group_rules format.


## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
