### PR TITLE
feat: Add `Name` tag to security group created

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -179,7 +179,7 @@ resource "aws_security_group" "this" {
 
   tags = merge(
     var.tags,
-    local.security_group_name != "" ? { Name = local.security_group_name } : {},
+    { Name = local.security_group_name },
   )
 
   lifecycle {

--- a/main.tf
+++ b/main.tf
@@ -177,7 +177,10 @@ resource "aws_security_group" "this" {
   revoke_rules_on_delete = true
   vpc_id                 = var.security_group_vpc_id
 
-  tags = var.tags
+  tags = merge(
+    var.tags,
+    local.security_group_name != "" ? { Name = local.security_group_name } : {},
+  )
 
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
## Description
Added tag with Name to aws_security_group for better UI appearance

## Motivation and Context
To have proper name for the SG in default AWS UI.
When var.security_group_name is set also add Name to tags.

## Breaking Changes
nope

## How Has This Been Tested?
tested from the fork

<img width="433" alt="Bildschirmfoto 2025-03-18 um 12 46 12" src="https://github.com/user-attachments/assets/5b77b3e1-2f9f-4ee7-9731-fbbc19694fe7" />
