### PR TITLE
docs: Update import commands for state changes section

### DIFF
--- a/docs/UPGRADE-2.0.md
+++ b/docs/UPGRADE-2.0.md
@@ -132,7 +132,7 @@ Due to the change from `aws_security_group_rule` to `aws_vpc_security_group_ingr
 
 ```sh
 terraform state rm 'module.efs.aws_security_group_rule.this["vpc"]'
-terraform state import 'module.efs.aws_vpc_security_group_ingress_rule.this["vpc_1"]' 'sg-xxx'
-terraform state import 'module.efs.aws_vpc_security_group_ingress_rule.this["vpc_2"]' 'sg-xxx'
-terraform state import 'module.efs.aws_vpc_security_group_ingress_rule.this["vpc_3"]' 'sg-xxx'
+terraform state import 'module.efs.aws_vpc_security_group_ingress_rule.this["vpc_1"]' 'sgr-xxx'
+terraform state import 'module.efs.aws_vpc_security_group_ingress_rule.this["vpc_2"]' 'sgr-xxx'
+terraform state import 'module.efs.aws_vpc_security_group_ingress_rule.this["vpc_3"]' 'sgr-xxx'
 ```


### PR DESCRIPTION
## Description
Update `terraform import` example commands in [UPGRADE-2.0.md](https://github.com/terraform-aws-modules/terraform-aws-efs/blob/master/docs/UPGRADE-2.0.md).

Current `terraform import` commands in the _State Changes_ example snippet suggest importing SG rules, created via pre 2.0 module versions, using the pattern of an SG rule ID that belongs to [aws_security_group_rule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule#import) resource (i.e. `sg-xxx`).
Meanwhile, the [aws_vpc_security_group_ingress_rule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule#import) resource ID for import is slightly different (i.e. `sgr-xxx`).

## Motivation and Context
- Accurate documentation is nice

## Breaking Changes
- N/A

## How Has This Been Tested?
- [x] I have executed `pre-commit run -a` on my pull request
