### PR TITLE
fix: Remove size_in_bytes output to prevent persistent plan drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,6 @@ No modules.
 | <a name="output_replication_configuration_destination_file_system_id"></a> [replication\_configuration\_destination\_file\_system\_id](#output\_replication\_configuration\_destination\_file\_system\_id) | The file system ID of the replica |
 | <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | ARN of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | ID of the security group |
-| <a name="output_size_in_bytes"></a> [size\_in\_bytes](#output\_size\_in\_bytes) | The latest known metered size (in bytes) of data stored in the file system, the value is not the exact size that the file system was at any point in time |
 <!-- END_TF_DOCS -->
 
 ## License

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -65,7 +65,6 @@ No inputs.
 | <a name="output_replication_configuration_destination_file_system_id"></a> [replication\_configuration\_destination\_file\_system\_id](#output\_replication\_configuration\_destination\_file\_system\_id) | The file system ID of the replica |
 | <a name="output_security_group_arn"></a> [security\_group\_arn](#output\_security\_group\_arn) | ARN of the security group |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | ID of the security group |
-| <a name="output_size_in_bytes"></a> [size\_in\_bytes](#output\_size\_in\_bytes) | The latest known metered size (in bytes) of data stored in the file system, the value is not the exact size that the file system was at any point in time |
 <!-- END_TF_DOCS -->
 
 Apache-2.0 Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-aws-efs/blob/master/LICENSE).

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -17,11 +17,6 @@ output "dns_name" {
   value       = module.efs.dns_name
 }
 
-output "size_in_bytes" {
-  description = "The latest known metered size (in bytes) of data stored in the file system, the value is not the exact size that the file system was at any point in time"
-  value       = module.efs.size_in_bytes
-}
-
 ################################################################################
 # Mount Target(s)
 ################################################################################

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,11 +17,6 @@ output "dns_name" {
   value       = try(aws_efs_file_system.this[0].dns_name, null)
 }
 
-output "size_in_bytes" {
-  description = "The latest known metered size (in bytes) of data stored in the file system, the value is not the exact size that the file system was at any point in time"
-  value       = try(aws_efs_file_system.this[0].size_in_bytes, null)
-}
-
 ################################################################################
 # Mount Target(s)
 ################################################################################


### PR DESCRIPTION
## Problem

The `size_in_bytes` output exposes a **computed-only, read-only** attribute from `aws_efs_file_system` that reflects the current metered filesystem size. This value changes constantly as data is written or deleted, causing persistent drift on every `terraform plan`:

```
Note: Objects have changed outside of Terraform

  # aws_efs_file_system.this[0] has changed
  ~ resource "aws_efs_file_system" "this" {
      ~ size_in_bytes = [
          ~ {
              ~ value             = 6144 -> 8959713280
              ~ value_in_standard = 6144 -> 8959713280
            },
        ]
    }

Changes to Outputs:
  ~ size_in_bytes = [
      ~ {
          ~ value             = 6144 -> 8959713280
          ~ value_in_standard = 6144 -> 8959713280
        },
    ]
```

This is problematic because:
- It generates noise in CI/CD pipelines, making genuine drift harder to spot
- It causes confusion in code reviews when every plan shows "changes"
- The value is inherently volatile and unreliable as a Terraform dependency

Related issues: #17, #27

## Solution

Remove the `size_in_bytes` output from the module.

`lifecycle { ignore_changes = [size_in_bytes] }` was also considered, but:
- It only suppresses the resource-level drift message — the **output still shows changes** on every plan
- OpenTofu treats `ignore_changes` on purely computed attributes as redundant (warning + no effect)
- Removing the output addresses both the resource drift noise and the output drift

Users who need to monitor filesystem size can use `data.aws_efs_file_system` or AWS CloudWatch metrics (`BurstCreditBalance`, `MeteredIOBytes`), which are better suited for monitoring purposes.

## Breaking change?

Technically, removing an output is a breaking change. However, I would argue this could go in a minor release (2.x) because:

- **Nobody is realistically depending on this output.** The value is never the same between two consecutive plans — it would be unusable as an input to another resource or module. Any dependency on it would cause perpetual changes downstream.
- The output description itself acknowledges this: *"the value is not the exact size that the file system was at any point in time"*
- Anyone who truly needs this data should be using `data.aws_efs_file_system` or CloudWatch anyway, which provide point-in-time reads rather than stale state values.

## Disclosure

This PR was made with the help of AI.